### PR TITLE
Fix missing ListKW global instance

### DIFF
--- a/ank-core/build.gradle
+++ b/ank-core/build.gradle
@@ -23,10 +23,10 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$parent.ext.kotlin_version"
     compile "org.jetbrains:markdown:0.1.25"
     compile "com.github.kategory:kategory:master-SNAPSHOT"
-    compile "io.kategory:kategory-annotations:0.3.6"
+    compile "io.kategory:kategory-annotations:0.3.7"
     compile "org.jetbrains.kotlin:kotlin-compiler:$parent.ext.kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-script-util:$parent.ext.kotlin_version"
-    kapt "io.kategory:kategory-annotations-compile:0.3.6"
+    kapt "io.kategory:kategory-annotations-compile:0.3.7"
 
     testCompile "junit:junit:$parent.ext.junit_version"
 }

--- a/ank-core/src/main/kotlin/io/kategory/ank/ank.kt
+++ b/ank-core/src/main/kotlin/io/kategory/ank/ank.kt
@@ -10,16 +10,17 @@ const val KotlinBlock = "kotlin"
 
 fun ank(source: File, target: File, compilerArgs: ListKW<String>) =
         AnkOps.binding {
+            val T = ListKW.traverse()
             val targetDirectory: File = createTarget(source, target).bind()
             val files: ListKW<File> = getFileCandidates(targetDirectory).bind()
-            val filesContents: ListKW<String> = files.map(::readFile).k().sequence().bind()
-            val parsedMarkDowns: ListKW<ASTNode> = filesContents.map(::parseMarkdown).k().sequence().bind()
+            val filesContents: ListKW<String> = files.map(::readFile).k().sequence(T).bind()
+            val parsedMarkDowns: ListKW<ASTNode> = filesContents.map(::parseMarkdown).k().sequence(T).bind()
             val allSnippets: ListKW<ListKW<Snippet>> = parsedMarkDowns.mapIndexed { n, tree ->
                 extractCode(filesContents.list[n], tree)
-            }.k().sequence().bind()
+            }.k().sequence(T).bind()
             val compilationResults =
-                    ListKW(allSnippets.mapIndexed { n, s -> compileCode(files.list[n], s, compilerArgs) }).k().sequence().bind()
-            val replacedResults: ListKW<String> = compilationResults.mapIndexed { n , c ->  replaceAnkToKotlin(c) }.k().sequence().bind()
+                    ListKW(allSnippets.mapIndexed { n, s -> compileCode(files.list[n], s, compilerArgs) }).k().sequence(T).bind()
+            val replacedResults: ListKW<String> = compilationResults.mapIndexed { n , c ->  replaceAnkToKotlin(c) }.k().sequence(T).bind()
             val resultingFiles: ListKW<File> = generateFiles(files, replacedResults).bind()
             yields(resultingFiles)
         }


### PR DESCRIPTION
- Fixes missing `ListKW` Kategory global instance passing `ListKW.traverse()` explicitly as parameter of `sequence` 
- Bumps Kategory annotations version to `0.3.7`

👀 @raulraja @pakoito 