### PR TITLE
Release core 0.1.1 and plugin 0.1.3

### DIFF
--- a/ank-core/build.gradle
+++ b/ank-core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-kapt'
 apply from: 'generated-kotlin-sources.gradle'
 
 group = 'io.kategory'
-version = '0.1.1'
+version = '0.1.2'
 
 sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/ank-core/gradle.properties
+++ b/ank-core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.1
+VERSION_NAME=0.1.2
 POM_ARTIFACT_ID=ank-core
 POM_NAME=Ank Core
 POM_DESCRIPTION=Compile time docs verification for Kotlin (Core)

--- a/ank-gradle-plugin/build.gradle
+++ b/ank-gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-gradle-plugin'
 apply plugin: 'kotlin'
 
 group = 'io.kategory'
-version = '0.1.3'
+version = '0.1.4'
 
 sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/ank-gradle-plugin/gradle.properties
+++ b/ank-gradle-plugin/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.3
+VERSION_NAME=0.1.4
 POM_ARTIFACT_ID=ank-gradle-plugin
 POM_NAME=Ank Gradle Plugin
 POM_DESCRIPTION=Compile time docs verification for Kotlin (Gradle Plugin)


### PR DESCRIPTION
- `ank-core` version `0.1.1` is now available in jcenter 🎉
- `ank-gradle-plugin` version `0.1.3` is now available in jcenter 🎉
- Bumps version numbers (`ank-core` to `0.1.2` and `ank-gradle-plugin` to `0.1.4`)

👀 @raulraja @pakoito 