### PR TITLE
Release core 0.1.2 and plugin 0.1.4

### DIFF
--- a/ank-core/build.gradle
+++ b/ank-core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-kapt'
 apply from: 'generated-kotlin-sources.gradle'
 
 group = 'io.kategory'
-version = '0.1.2'
+version = '0.1.3'
 
 sourceSets {
     main.java.srcDirs += 'src/main/kotlin'
@@ -22,11 +22,11 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$parent.ext.kotlin_version"
     compile "org.jetbrains:markdown:0.1.25"
-    compile "com.github.kategory:kategory:master-SNAPSHOT"
-    compile "io.kategory:kategory-annotations:0.3.6"
+    compile "io.kategory:kategory:0.3.5"
+    compile "io.kategory:kategory-annotations:0.3.7"
     compile "org.jetbrains.kotlin:kotlin-compiler:$parent.ext.kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-script-util:$parent.ext.kotlin_version"
-    kapt "io.kategory:kategory-annotations-compile:0.3.6"
+    kapt "io.kategory:kategory-annotations-compile:0.3.7"
 
     testCompile "junit:junit:$parent.ext.junit_version"
 }

--- a/ank-core/gradle.properties
+++ b/ank-core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.2
+VERSION_NAME=0.1.3
 POM_ARTIFACT_ID=ank-core
 POM_NAME=Ank Core
 POM_DESCRIPTION=Compile time docs verification for Kotlin (Core)

--- a/ank-gradle-plugin/build.gradle
+++ b/ank-gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-gradle-plugin'
 apply plugin: 'kotlin'
 
 group = 'io.kategory'
-version = '0.1.4'
+version = '0.1.5'
 
 sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/ank-gradle-plugin/gradle.properties
+++ b/ank-gradle-plugin/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.1.4
+VERSION_NAME=0.1.5
 POM_ARTIFACT_ID=ank-gradle-plugin
 POM_NAME=Ank Gradle Plugin
 POM_DESCRIPTION=Compile time docs verification for Kotlin (Gradle Plugin)

--- a/ank-gradle-plugin/src/main/kotlin/io/kategory/ank/AnkPlugin.kt
+++ b/ank-gradle-plugin/src/main/kotlin/io/kategory/ank/AnkPlugin.kt
@@ -12,7 +12,7 @@ class AnkPlugin : Plugin<Project> {
     companion object {
         private val EXTENSION_NAME = "ank"
         private val TASK_NAME = "runAnk"
-        private val ANK_CORE_DEPENDENCY = "io.kategory:ank-core:0.1.1"
+        private val ANK_CORE_DEPENDENCY = "io.kategory:ank-core:0.1.2"
     }
 
     override fun apply(target: Project) {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath group: 'io.kategory', name: 'ank-gradle-plugin', version: '0.1.3'
+        classpath group: 'io.kategory', name: 'ank-gradle-plugin', version: '0.1.4'
     }
 }
 


### PR DESCRIPTION
- `ank-core` version `0.1.2` is now available in jcenter 🎉
- `ank-gradle-plugin` version `0.1.4` is now available in jcenter 🎉
- Bumps version numbers (`ank-core` to `0.1.3` and `ank-gradle-plugin` to `0.1.5`)
- Bumps `kategory-annotations` and `kategory-annotations-compile` dependencies to `0.3.7` version
- Fixes `kategory` dependency to use last release version `0.3.5`
- Fixes `ank-gradle-plugin` dependency to `0.1.4` in `sample` module
- Bumps `ank-core` dependency to `0.1.2` in `AnkPlugin`

👀 @raulraja @pakoito 