### PR TITLE
Bug fixes and better error reporting

### DIFF
--- a/ank-core/src/main/kotlin/io/kategory/ank/ank.kt
+++ b/ank-core/src/main/kotlin/io/kategory/ank/ank.kt
@@ -19,7 +19,7 @@ fun ank(source: File, target: File, compilerArgs: ListKW<String>) =
             }.k().sequence().bind()
             val compilationResults =
                     ListKW(allSnippets.mapIndexed { n, s -> compileCode(files.list[n], s, compilerArgs) }).k().sequence().bind()
-            val replacedResults: ListKW<String> = compilationResults.mapIndexed { n , c ->  replaceAnkToKotlin(c) }.k().sequence().bind()
+            val replacedResults: ListKW<String> = compilationResults.map { c ->  replaceAnkToKotlin(c) }.k().sequence().bind()
             val resultingFiles: ListKW<File> = generateFiles(files, replacedResults).bind()
             yields(resultingFiles)
         }

--- a/ank-core/src/main/kotlin/io/kategory/ank/interpreter.kt
+++ b/ank-core/src/main/kotlin/io/kategory/ank/interpreter.kt
@@ -74,8 +74,12 @@ fun extractCodeImpl(source: String, tree: ASTNode): ListKW<Snippet> {
         override fun visitNode(node: ASTNode) {
             if (node.type == CODE_FENCE) {
                 val fence = node.getTextInNode(source)
-                val code = fence.split("\n").drop(1).dropLast(1).joinToString("\n")
-                sb.add(Snippet(fence.startsWith("```$AnkSilentBlock"), node.startOffset, node.endOffset, code))
+                if (fence.startsWith("```$AnkBlock")) {
+                    val code = fence.split("\n").drop(1).dropLast(1).joinToString("\n")
+                    sb.add(Snippet(fence.startsWith("```$AnkSilentBlock"), node.startOffset, node.endOffset, code))
+                } else {
+                    println("skipped: \n $fence")
+                }
             }
             super.visitNode(node)
         }

--- a/ank-gradle-plugin/src/main/kotlin/io/kategory/ank/AnkPlugin.kt
+++ b/ank-gradle-plugin/src/main/kotlin/io/kategory/ank/AnkPlugin.kt
@@ -12,7 +12,7 @@ class AnkPlugin : Plugin<Project> {
     companion object {
         private val EXTENSION_NAME = "ank"
         private val TASK_NAME = "runAnk"
-        private val ANK_CORE_DEPENDENCY = "io.kategory:ank-core:0.1.2"
+        private val ANK_CORE_DEPENDENCY = "io.kategory:ank-core:0.1.3"
     }
 
     override fun apply(target: Project) {

--- a/ank-gradle-plugin/src/main/kotlin/io/kategory/ank/AnkPlugin.kt
+++ b/ank-gradle-plugin/src/main/kotlin/io/kategory/ank/AnkPlugin.kt
@@ -27,7 +27,7 @@ class AnkPlugin : Plugin<Project> {
         })
         val extension = AnkExtension()
         target.extensions.add(EXTENSION_NAME, extension)
-        target.afterEvaluate { project ->
+        target.afterEvaluate { _ ->
             val task = target.tasks.create(TASK_NAME, JavaExec::class.java)
             task.classpath = extension.classpath
             task.main = "io.kategory.ank.main"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath group: 'io.kategory', name: 'ank-gradle-plugin', version: '0.1.4'
+        classpath group: 'io.kategory', name: 'ank-gradle-plugin', version: '0.1.5'
     }
 }
 

--- a/sample/src/main/docs/doc1.md
+++ b/sample/src/main/docs/doc1.md
@@ -1,5 +1,171 @@
-Welcome to doc one
+---
+layout: docs
+title: Option
+permalink: /docs/datatypes/option/
+---
+
+## Option
+
+If you have worked with Java at all in the past, it is very likely that you have come across a `NullPointerException` at some time (other languages will throw similarly named errors in such a case). Usually this happens because some method returns `null` when you were not expecting it and thus not dealing with that possibility in your client code. A value of `null` is often abused to represent an absent optional value.
+Kotlin tries to solve the problem by getting rid of `null` values altogether and providing its own special syntax [Null-safety machinery based on `?`](https://kotlinlang.org/docs/reference/null-safety.html).
+
+Kategory models the absence of values through the `Option` datatype similar to how Scala, Haskell and other FP languages handle optional values.
+ 
+`Option<A>` is a container for an optional value of type `A`. If the value of type `A` is present, the `Option<A>` is an instance of `Some<A>`, containing the present value of type `A`. If the value is absent, the `Option<A>` is the object `None`.
+ 
+
 
 ```kotlin:ank
-val x = 0
+import kategory.*
+import kategory.Option.*
+
+val someValue: Option<String> = Some("I am wrapped in something")
+someValue
 ```
+
+```kotlin:ank
+val emptyValue: Option<String> = None
+emptyValue
+```
+
+Let's write a function that may or not give us a string, thus returning `Option<String>`:
+
+```kotlin:ank:silent
+fun maybeItWillReturnSomething(flag: Boolean): Option<String> = 
+   if (flag) Some("Found value") else None
+```
+
+Using `getOrElse` we can provide a default value `"No value"` when the optional argument `None` does not exist:
+ 
+```kotlin:ank:silent
+val value1 = maybeItWillReturnSomething(true)
+val value2 = maybeItWillReturnSomething(false)
+```
+
+```kotlin:ank
+value1.getOrElse { "No value" }
+```
+
+```kotlin:ank
+value2.getOrElse { "No value" }
+```
+
+Checking whether option has value:
+
+```kotlin:ank
+value1 is None
+```
+
+```kotlin:ank
+value2 is None
+```
+
+Option can also be used with when statements:
+
+```kotlin:ank
+val someValue: Option<Double> = Some(20.0)
+when(someValue) {
+   is Some -> someValue.value
+   is None -> 0.0
+}
+```
+
+```kotlin:ank
+val noValue: Option<Double> = None
+when(noValue) {
+   is Some -> noValue.value
+   is None -> 0.0
+}
+```
+
+An alternative for pattern matching is performing Functor/Foldable style operations. This is possible because an option could be looked at as a collection or foldable structure with either one or zero elements.
+ 
+One of these operations is `map`. This operation allows us to map the inner value to a different type while preserving the option:
+ 
+```kotlin:ank:silent
+val number: Option<Int> = Some(3)
+val noNumber: Option<Int> = None
+val mappedResult1 = number.map { it * 1.5 }
+val mappedResult2 = noNumber.map { it * 1.5 }
+```
+
+```kotlin:ank
+mappedResult1
+```
+
+```kotlin:ank
+mappedResult2
+```
+ 
+Another operation is `fold`. This operation will extract the value from the option, or provide a default if the value is `None`
+ 
+```kotlin:ank
+number.fold({ 1 }, { it * 3 })
+```
+
+```kotlin:ank
+noNumber.fold({ 1 }, { it * 3 })
+```
+
+Kategory also adds syntax to all datatypes so you can easily lift them into the context of `Option` where needed.
+
+```kotlin:ank
+1.some()
+```
+
+```kotlin:ank
+none<String>()
+```
+
+Kategory contains `Option` instances for many useful typeclasses that allows you to use and transform optional values
+
+[`Functor`](/docs/typeclasses/functor/)
+
+Transforming the inner contents
+
+```kotlin:ank
+Option.functor().map(Option(1), { it + 1 })
+```
+
+[`Applicative`](/docs/typeclasses/applicative/)
+
+Computing over independent values
+
+```kotlin:ank
+Option.applicative().tupled(Option(1), Option("Hello"), Option(20.0))
+```
+
+[`Monad`](/docs/typeclasses/monad/)
+
+Computing over dependent values ignoring absence
+
+```kotlin
+val r1 = Option.monad().binding {
+   val a = Option(1).bind()
+   val b = Option(1 + x).bind()
+   val c = Option(1 + y).bind()
+   yields(a + b + c)
+}
+```
+
+```kotlin
+val r2 = Option.monad().binding {
+   val x = none<Int>().bind()
+   val y = Option(1 + x).bind()
+   val z = Option(1 + y).bind()
+   yields(x + y + z)
+}
+```
+
+Other instances exist for:
+
+[`Foldable`](/docs/typeclasses/foldable/)
+[`Traverse`](/docs/typeclasses/traverse/)
+[`Semigroup`](/docs/typeclasses/semigroup/)
+[`Monoid`](/docs/typeclasses/monoid/)
+[`MonadError`](/docs/typeclasses/monaderror/)
+ 
+# Credits
+ 
+Contents partially adapted from [Scala Exercises Option Tutorial](https://www.scala-exercises.org/std_lib/options)
+Originally based on the Scala Koans.


### PR DESCRIPTION
- [x] Code fences that do not start with ```kotlin:ank are ignored. Fixes #16
- [x] Friendlier error messages including  code fences are shown like the one below. Fixes #14

```
### ΛNK Compilation Error ###
```
x
mappedResult1
```

error: unresolved reference: x
x
^

##############################

        at io.kategory.ank.InterpreterKt$compileCodeImpl$evaledSnippets$1$result$2.invoke(interpreter.kt:112)
        at io.kategory.ank.InterpreterKt$compileCodeImpl$evaledSnippets$1$result$2.invoke(interpreter.kt)
        at kategory.Try.fold(Try.kt:75)
        at io.kategory.ank.InterpreterKt.compileCodeImpl(interpreter.kt:111)
        at io.kategory.ank.main$main$$inlined$ankMonadErrorInterpreter$1$6.invoke(interpreter.kt:30)
        at io.kategory.ank.main$main$$inlined$ankMonadErrorInterpreter$1$6.invoke(interpreter.kt:21)
        at kategory.ApplicativeErrorKt.catch(ApplicativeError.kt:39)
        at io.kategory.ank.main$main$$inlined$ankMonadErrorInterpreter$1.invoke(interpreter.kt:30)
        at kategory.FreeKt$foldMap$1.invoke(Free.kt:83)
        at kategory.FreeKt$foldMap$1.invoke(Free.kt)
        at kategory.EitherInstances$DefaultImpls.tailRecM(EitherInstances.kt:18)
        at kategory.Either$Companion$instances$1.tailRecM(Either.kt:124)
        at kategory.Either$Companion$instances$1.tailRecM(Either.kt:124)
        at kategory.FreeKt.foldMap(Free.kt:79)
        at kategory.FreeKt$foldMap$1.invoke(Free.kt:87)
        at kategory.FreeKt$foldMap$1.invoke(Free.kt)
        at kategory.EitherInstances$DefaultImpls.tailRecM(EitherInstances.kt:18)
        at kategory.Either$Companion$instances$1.tailRecM(Either.kt:124)
        at kategory.Either$Companion$instances$1.tailRecM(Either.kt:124)
        at kategory.FreeKt.foldMap(Free.kt:79)
        at io.kategory.ank.main.main(main.kt:29)
:sample:runAnk FAILED
```