### PR TITLE
Unify versions

### DIFF
--- a/ank-core/build.gradle
+++ b/ank-core/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 apply from: 'generated-kotlin-sources.gradle'
 
-group = 'io.kategory'
-version = ank_version
+group = ext.ank_group
+version = ext.ank_version
 
 sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/ank-gradle-plugin/build.gradle
+++ b/ank-gradle-plugin/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'kotlin'
 
-group = 'io.kategory'
-version = ank_version
+group = ext.ank_group
+version = ext.ank_version
 
 sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/build.gradle
+++ b/build.gradle
@@ -12,13 +12,12 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath group: 'io.kategory', name: 'ank-gradle-plugin', version: '0.1.5'
+        classpath group: 'io.kategory', name: 'ank-gradle-plugin', version: '0.1.6'
     }
 }
 
 subprojects { project ->
 
-    ank_version = "0.1.6"
     apply plugin: 'com.jfrog.bintray'
     bintray {
         user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
@@ -35,6 +34,11 @@ subprojects { project ->
 }
 
 allprojects {
+
+    ext {
+        ank_group = 'io.kategory'
+        ank_version = '0.1.6'
+    }
 
     repositories {
         jcenter()


### PR DESCRIPTION
- `ank-core` version `0.1.6` is now available in jcenter 🎉
- `ank-gradle-plugin` version `0.1.6` is now available in jcenter 🎉
- Extracts external variables (`ank_group` and `ank_version`)
- Bumps `ank-gradle-plugin` version to `0.1.6`

👀 @raulraja 